### PR TITLE
[#15] docker-compose 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 __pycache__
 /dev.cfg
+/.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,4 @@ RUN pip install -r requirements.txt
 
 EXPOSE 80
 
-WORKDIR /src
-
 CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -2,72 +2,37 @@
 당신의 모든 질문, 모든 세상이 답변합니다.
 
 # Build & Running
-## With Docker
-여기부터 기술된 모든 bash 명령은 **프로젝트 루트에서 실행**합니다.
+### Prerequisite
+- [Docker](https://docs.docker.com/engine/installation/) >= 17.03.1-ce
+- [Docker Compose](https://docs.docker.com/compose/install/) >= 1.11.2
 
-#### Preparing Images
+### Environment Setup
+`./docs/example.env`와 `./docs/example.dev.cfg`를 참고해 `.env`와 `dev.cfg`를 프로젝트 루트에 생성합니다.
+
+### Running
 ```bash
-docker pull postgres
-docker build -t randompoll .
+cd /path/to/random-poll
+docker-compose up
 ```
 
-#### Running Database
+이제 어플리케이션에 필요한 모든 컨테이너가 맞물려 실행됩니다.
+
+### Database
+#### Initialization
+데이터베이스를 초기화하려면 우선 `docker ps`로 `web` 컨테이너의 ID를 확인해 접속합니다.
 ```bash
-docker run --name rp-postgres -e POSTGRES_PASSWORD=<db-password> -d postgres
+docker exec -it <web-container-id> /bin/bash
 ```
 
-`<db-password>`는 원하는 값으로 적절히 선택합니다.
-다음 명령어로 `rp-postgres` 컨테이너의 `bridge` 네트워크상에서의 IP 주소를 알아냅니다.
-
-```bash
-docker network inspect bridge
-```
-
-#### Running Server
-위에서 알아낸 `rp-postgres`의 주소와 직접 설정한 `<db-password>`를 바탕으로 `dev.cfg`를 프로젝트 루트에 생성한 후(`./docs/example.dev.cfg`를 참고), 원하는 포트에 서버를 실행합니다. 아래 예시에선 7654번 포트에 띄웠습니다.
-
-```bash
-docker run --rm -it -v `pwd`:/src -p 7654:80 randompoll
-```
-
-#### Initializing Database
-`randompoll` 컨테이너에 접속합니다. 우선 다음 명령어로 현재 실행중인 컨테이너의 ID를 확인합니다.
-
-```bash
-docker ps
-```
-
-ID를 확인했으면 이제 컨테이너 내에서 `bash` 쉘을 실행합니다.
-
-```bash
-docker exec -it <randompoll-container-id> /bin/bash
-```
-
-이제 `/src`로 이동한 후, `python` 쉘을 띄우고 다음을 실행합니다.
+이후 컨테이너 내부에서 `/app`으로 이동해 Python shell을 띄운 후 다음을 실행합니다.
 
 ```python
 from main import db
 db.create_all()
 ```
 
-#### Test
-브라우저로 `localhost:7654`에 접속해봅니다.
-
-## Without Docker
-#### Installing Dependencies
-```plain
-pip install -r requirements.txt
-```
-
-#### Initializing Database
-PostgreSQL을 먼저 설치하신 후, 적절한 데이터베이스를 생성합니다. 준비가 다 되었다면 테이블을 만들 차례입니다. Working directory에서 Python shell을 띄운 후 다음을 실행합니다.
-```python
-from main import db
-db.create_all()
-```
-
-#### Running Server
-`dev.cfg`를 환경에 맞게 적절히 작성한 후 다음을 실행합니다.
+#### Interaction
+외부에서 `psql`로 접속해 데이터베이스의 상태를 확인할 필요가 있다면, `.env`에서 설정한 `DB_EXTERNAL_PORT` 값에 따라 접속합니다.
 ```bash
-python main.py
+psql -h localhost -p <db-external-port> -U postgres
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - "${APP_EXTERNAL_PORT}:80"
+    volumes:
+      - .:/app
+  postgres:
+    image: "postgres"
+    ports:
+      - "${DB_EXTERNAL_PORT}:5432"
+    environment:
+      POSTGRES_PASSWORD: "${DB_PASSWORD}"

--- a/docs/example.dev.cfg
+++ b/docs/example.dev.cfg
@@ -1,5 +1,5 @@
 [database]
-host=<host>
+host=postgres
 user=postgres
 password=<password>
 database=postgres

--- a/docs/example.env
+++ b/docs/example.env
@@ -1,0 +1,3 @@
+APP_EXTERNAL_PORT=<port>
+DB_PASSWORD=<password>
+DB_EXTERNAL_PORT=<port>


### PR DESCRIPTION
## Related Issue
#15, #11 

## Purpose
`docker-compose`를 활용해 앱 관리를 효율적이고 간편하게 합니다.

## Overview
앱의 모든 라이프사이클 관리를 `docker-compose`만으로 처리할 수 있도록 `docker-compose.yml`을 작성하고 기타 파일들을 업데이트합니다.

## Comment
### 준비
- `docker-compose`를 설치합니다. Mac의 경우 Docker만 설치해도 알아서 설치됩니다.
- `./docs/example.env`를 참고해 프로젝트 루트에 `.env` 파일을 생성합니다.
- `./docs/example.dev.cfg`를 참고해 `dev.cfg`를 업데이트합니다. `database` 섹션의 `host`를 `postgres`로 설정하고, `password`를 `.env`와 일치하게 하는 것을 잊지 마십시오.

### 실행
```bash
cd /path/to/random-poll
docker-compose up
```

위 명령어만으로 **앱과 DB의 컨테이너를 모두 연결된 채로 띄울 수 있습니다!** 이후 `Ctrl+C`를 통해 종료할 수 있습니다.

### 추가 작업 이슈
- `dev.cfg`가 아예 필요 없어질 수도 있겠습니다. 현재 DB 패스워드를 두 파일에 동시에 기록해야 하는데, 실행 파일 자체도 `.env`를 읽도록 해 정보를 통일하는 편이 좋을 것 같습니다.
- 새로운 실행 과정을 `README.md`에 정리해야 합니다.
- DB 초기화 작업은 아직 자동화되지 않았습니다. 이 또한 충분히 자동화 가능하나, 다른 이슈에서 처리할 필요가 있습니다.