### PR TITLE
Docker가 app을 unbuffered output mode로 실행하게 함

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install -r requirements.txt
 
 EXPOSE 80
 
-CMD ["python", "main.py"]
+CMD ["python", "-u", "main.py"]


### PR DESCRIPTION
## Related Issue
#23

## Purpose
 - Docker 내부의 출력에서 python web server app의 `print`문이 정상적으로 보이도록 합니다.

## Overview
 - Docker에서 python web server app을 unbuffered output mode로 실행합니다.

## Comment
 - 너무 간단한 변경 사항이라 별다를건 없네요
 - `Dockerfile`에 변경이 생기기 때문에 `$ docker-compose build`를 한차례 실행해준 뒤 `$ docker-compose up`을 실행해야 할 것 같습니다. shortcurt은 `$ docker-compose up --build` 입니다.